### PR TITLE
Fix SyntaxError: Identifier 'core' has already been declared

### DIFF
--- a/lib/variableSubstitution.js
+++ b/lib/variableSubstitution.js
@@ -10,7 +10,6 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-const core = require("@actions/core");
 const envVariableUtility_1 = require("./operations/envVariableUtility");
 const jsonVariableSubstitutionUtility_1 = require("./operations/jsonVariableSubstitutionUtility");
 const xmlDomUtility_1 = require("./xmlDomUtility");


### PR DESCRIPTION
Related to #4

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PavanMudigondaTR/variable-substitution/pull/5?shareId=39fbc2c0-963f-41c8-adb4-cf20b438d58d).